### PR TITLE
Automate version string.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: clean
+
+bin := bitrot
+bindir := /usr/local/bin
+src := $(wildcard *.go)
+git_tag := $(shell git describe --tags)
+
+# Default target
+${bin}: Makefile ${src}
+	go build -v -ldflags "-X main.Build=${git_tag}" -o "${bin}"
+
+clean:
+	rm -f "${bin}"
+
+install: ${bin}
+	install -m 755 "${bin}" "${bindir}"

--- a/dirtree.go
+++ b/dirtree.go
@@ -77,7 +77,7 @@ func (d *DirTree) compareFile(fname string) (string, error) {
 			memfi.Md5sum = md5sum
 			d.Files[fname] = memfi
 		} else {
-			Log.Verbosef(1, "[No metadata changes] %s (%x)", fname, md5sum)
+			Log.Verbosef(1, "[No metadata changes] %s (%x)\n", fname, md5sum)
 			// Exists: No metadata changes. Report md5 differences
 			for k := range md5sum {
 				if memfi.Md5sum[k] != md5sum[k] {

--- a/main.go
+++ b/main.go
@@ -16,8 +16,10 @@ import (
 	"github.com/marcopaganini/logger"
 )
 
+// This is filled by go build -ldflags during build.
+var Build string
+
 const (
-	version        = "1.0.0"
 	stateDirPrefix = ".bitrot"
 	stateFileMask  = "bitrot_%x.db.gz"
 	stateDirMode   = 0770
@@ -77,7 +79,7 @@ func parseFlags() error {
 	flag.Parse()
 
 	if Opt.version {
-		fmt.Println(version)
+		fmt.Printf("bitrot build: %s\n", Build)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
- Automate version string to contain the git commit #.
- Build now under 'make' control (added Makefile.)
- Fix small printing bug in verbose mode.
