### PR TITLE
Add multiple architecture auto build support.

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -1,0 +1,33 @@
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.x
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: "Build & test"
+        run: |
+          make arch
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            arch/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bitrot
 # Folders
 _obj
 _test
+arch
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: clean
+.PHONY: arch clean install
 
 bin := bitrot
 bindir := /usr/local/bin
+archdir := arch
 src := $(wildcard *.go)
 git_tag := $(shell git describe --tags)
 
@@ -11,6 +12,19 @@ ${bin}: Makefile ${src}
 
 clean:
 	rm -f "${bin}"
+	rm -rf "${archdir}"
 
 install: ${bin}
 	install -m 755 "${bin}" "${bindir}"
+
+# Creates cross-compiled tarred versions (for releases).
+arch: Makefile ${src}
+	for ga in "linux/amd64" "linux/386" "linux/arm" "linux/arm64" "linux/mips" "linux/mipsle"; do \
+	  export GOOS="$${ga%/*}"; \
+	  export GOARCH="$${ga#*/}"; \
+	  dst="./${archdir}/$${GOOS}-$${GOARCH}"; \
+	  mkdir -p "$${dst}"; \
+	  go build -v -ldflags "-X main.Build=${git_tag}" -o "$${dst}/${bin}"; \
+	  install -m 644 LICENSE README.md "$${dst}"; \
+	  tar -C "${archdir}" -zcvf "${archdir}/${bin}-$${GOOS}-$${GOARCH}.tar.gz" "$${dst##*/}"; \
+	done


### PR DESCRIPTION
- Makefile can now create multiple architecture targets.
- Add Github action to automatically create new release on version tag.
